### PR TITLE
Add initial support for RedHat family of systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can find more examples in the examples dir.
 
 ## TODO
 
-* Add support for RedHat based systems 
+* Add support for RedHat based systems  -  First pass done.  Based on custom built package v0.9.13
 
 ## Links
 

--- a/files/init.d/conntrackd
+++ b/files/init.d/conntrackd
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# conntrackd    Start conntrackd using /etc/conntrackd/conntrackd.conf
+#
+#               Written by Max Kellermann <max@duempel.org>
+#
+#   Linux chkconfig stuff:
+#
+#   chkconfig: 2345 25 10 
+#   description: Startup/shutdown script for conntrackd.
+#
+#
+### BEGIN INIT INFO
+# Provides:          conntrackd
+# Required-Start:    $network $syslog $remote_fs
+# Required-Stop:     $network $syslog $remote_fs
+# Default-Start:     2 3 4 5 
+# Default-Stop:	     0 1 6 
+# Description: Starts conntrackd
+# short-description: Starts conntrackd
+### END INIT INFO
+
+#source function library
+. /etc/rc.d/init.d/functions
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/conntrackd
+
+test -x $DAEMON || exit 0
+
+CONFIG=/etc/conntrackd/conntrackd.conf
+OPTIONS=""
+
+test -f /etc/sysconfig/conntrackd && . /etc/sysconfig/conntrackd
+
+test -f $CONFIG || exit 0
+
+case "$1" in
+    start)
+        echo -n $"Starting conntrackd: "
+            $DAEMON -d -C "$CONFIG" $OPTIONS && success || failure
+        ;;
+    stop)
+        echo -n $"Stopping conntrackd: "
+        $DAEMON -C "$CONFIG" -k && success || failure
+        ;;
+    restart|force-reload)
+        $0 stop
+        sleep 1
+        $0 start
+        ;;
+    *)
+        echo $"Usage: /etc/init.d/conntrackd {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/files/primary-backup.sh
+++ b/files/primary-backup.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# 
+# (C) 2008 by Pablo Neira Ayuso <pablo@netfilter.org>
+#
+# This software may be used and distributed according to the terms
+# of the GNU General Public License, incorporated herein by reference.
+#
+# Description:
+#
+# This is the script for primary-backup setups for keepalived
+# (http://www.keepalived.org). You may adapt it to make it work with other
+# high-availability managers.
+#
+# Do not forget to include the required modifications to your keepalived.conf
+# file to invoke this script during keepalived's state transitions.
+#
+# Contributions to improve this script are welcome :).
+#
+
+CONNTRACKD_BIN=/usr/sbin/conntrackd
+CONNTRACKD_LOCK=/var/lock/conntrack.lock
+CONNTRACKD_CONFIG=/etc/conntrackd/conntrackd.conf
+
+case "$1" in
+  primary)
+    #
+    # commit the external cache into the kernel table
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -c
+    if [ $? -eq 1 ]
+    then
+        logger "ERROR: failed to invoke conntrackd -c"
+    fi
+
+    #
+    # flush the internal and the external caches
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -f
+    if [ $? -eq 1 ]
+    then
+    	logger "ERROR: failed to invoke conntrackd -f"
+    fi
+
+    #
+    # resynchronize my internal cache to the kernel table
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -R
+    if [ $? -eq 1 ]
+    then
+    	logger "ERROR: failed to invoke conntrackd -R"
+    fi
+
+    #
+    # send a bulk update to backups 
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -B
+    if [ $? -eq 1 ]
+    then
+        logger "ERROR: failed to invoke conntrackd -B"
+    fi
+    ;;
+  backup)
+    #
+    # is conntrackd running? request some statistics to check it
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -s
+    if [ $? -eq 1 ]
+    then
+        #
+	# something's wrong, do we have a lock file?
+	#
+    	if [ -f $CONNTRACKD_LOCK ]
+	then
+	    logger "WARNING: conntrackd was not cleanly stopped."
+	    logger "If you suspect that it has crashed:"
+	    logger "1) Enable coredumps"
+	    logger "2) Try to reproduce the problem"
+	    logger "3) Post the coredump to netfilter-devel@vger.kernel.org"
+	    rm -f $CONNTRACKD_LOCK
+	fi
+	$CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -d
+	if [ $? -eq 1 ]
+	then
+	    logger "ERROR: cannot launch conntrackd"
+	    exit 1
+	fi
+    fi
+    #
+    # shorten kernel conntrack timers to remove the zombie entries.
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -t
+    if [ $? -eq 1 ]
+    then
+    	logger "ERROR: failed to invoke conntrackd -t"
+    fi
+
+    #
+    # request resynchronization with master firewall replica (if any)
+    # Note: this does nothing in the alarm approach.
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -n
+    if [ $? -eq 1 ]
+    then
+    	logger "ERROR: failed to invoke conntrackd -n"
+    fi
+    ;;
+  fault)
+    #
+    # shorten kernel conntrack timers to remove the zombie entries.
+    #
+    $CONNTRACKD_BIN -C $CONNTRACKD_CONFIG -t
+    if [ $? -eq 1 ]
+    then
+    	logger "ERROR: failed to invoke conntrackd -t"
+    fi
+    ;;
+  *)
+    logger "ERROR: unknown state transition"
+    echo "Usage: primary-backup.sh {primary|backup|fault}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/files/sysconfig/conntrackd
+++ b/files/sysconfig/conntrackd
@@ -1,0 +1,5 @@
+# Which configuration file?
+#CONFIG=/etc/conntrackd/conntrackd.conf
+
+# Additional options for daemon startup.
+#OPTIONS=""

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -389,10 +389,11 @@ class conntrackd::config (
 
     #init.d start file
     file { '/etc/rc.d/init.d/conntrackd':
-      ensure => $config_exists,
-      source => "puppet:///${module_name}/init.d/conntrackd", 
-      mode   => '0755',
-      before => Service['conntrackd'],
+      ensure  => $config_exists,
+      source  => "puppet:///${module_name}/init.d/conntrackd", 
+      mode    => '0755',
+      before  => Service['conntrackd'],
+      require => File['/etc/sysconfig/conntrackd'],
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -367,4 +367,32 @@ class conntrackd::config (
     require => File['conntrackd-confdir'],
     notify  => Service['conntrackd'],
   }
+
+  # conntrack-tools needs a hand
+  if $::osfamily == 'RedHat' {
+
+    #primary-backup.sh for use with keepalived 
+    file { 'primary-backup.sh':
+      ensure  => $config_exists,
+      path    => "${conntrackd::params::config_dir}/${conntrackd::params::primary-backup_filename}",
+      source  => "puppet:///${module_name}/primary-backup.sh",
+      mode    => '0755',
+      require => File['conntrackd-confdir'],
+    }
+
+    #conntrackd options file
+    file { '/etc/sysconfig/conntrackd':
+      ensure => $config_exists,
+      source => "puppet:///${module_name}/sysconfig/conntrackd",
+      mode   => '0644',
+    }  
+
+    #init.d start file
+    file { '/etc/rc.d/init.d/conntrackd':
+      ensure => $config_exists,
+      source => "puppet:///${module_name}/init.d/conntrackd", 
+      mode   => '0755',
+      before => Service['conntrackd'],
+    }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -359,10 +359,16 @@ class conntrackd::config (
   }
 
   # configuration file
+
+  $conntrackd_conf_erb = $::osfamily ? {
+    'RedHat'  => 'conntrackd.conf.RedHat.erb',
+    default   => 'conntrackd.conf.erb',
+  }
+
   file { 'conntrackd-config':
     ensure  => $config_exists,
     path    => "${conntrackd::params::config_dir}/${conntrackd::params::config_filename}",
-    content => template('conntrackd/conntrackd.conf.erb'),
+    content => template("${module_name}/${conntrackd::config::conntrackd_conf_erb}"),
     mode    => '0644',
     require => File['conntrackd-confdir'],
     notify  => Service['conntrackd'],
@@ -374,8 +380,8 @@ class conntrackd::config (
     #primary-backup.sh for use with keepalived 
     file { 'primary-backup.sh':
       ensure  => $config_exists,
-      path    => "${conntrackd::params::config_dir}/${conntrackd::params::primary-backup_filename}",
-      source  => "puppet:///${module_name}/primary-backup.sh",
+      path    => "${conntrackd::params::config_dir}/${conntrackd::params::primary_backup_filename}",
+      source  => "puppet:///modules/${module_name}/primary-backup.sh",
       mode    => '0755',
       require => File['conntrackd-confdir'],
     }
@@ -383,14 +389,14 @@ class conntrackd::config (
     #conntrackd options file
     file { '/etc/sysconfig/conntrackd':
       ensure => $config_exists,
-      source => "puppet:///${module_name}/sysconfig/conntrackd",
+      source => "puppet:///modules/${module_name}/sysconfig/conntrackd",
       mode   => '0644',
     }  
 
     #init.d start file
     file { '/etc/rc.d/init.d/conntrackd':
       ensure  => $config_exists,
-      source  => "puppet:///${module_name}/init.d/conntrackd", 
+      source  => "puppet:///modules/${module_name}/init.d/conntrackd", 
       mode    => '0755',
       before  => Service['conntrackd'],
       require => File['/etc/sysconfig/conntrackd'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,7 @@ class conntrackd::params {
   # packages
   case $::osfamily {
     'RedHat': {
-      $package = [ 'contrack-tools' ]
+      $package = [ 'conntrack-tools' ]
     }
     'Debian': {
       $package = [ 'conntrackd' ]
@@ -79,7 +79,7 @@ class conntrackd::params {
   # location of configuration file
   $config_dir              = '/etc/conntrackd'
   $config_filename         = 'conntrackd.conf'
-  $primary-backup_filename = 'primary-backup.sh'
+  $primary_backup_filename = 'primary-backup.sh'
 
   # Configuration file parameters
   # -- Set the hashlimit to be double the sysctl value of net.nf_conntrack_max

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,11 +43,11 @@ class conntrackd::params {
   #### Internal module values
 
   # packages
-  case $::operatingsystem {
-    'CentOS', 'Fedora', 'Scientific': {
+  case $::osfamily {
+    'RedHat': {
       $package = [ 'contrack-tools' ]
     }
-    'Debian', 'Ubuntu': {
+    'Debian': {
       $package = [ 'conntrackd' ]
     }
     default: {
@@ -56,17 +56,15 @@ class conntrackd::params {
   }
 
   # service parameters
-  case $::operatingsystem {
-    # TODO: Include Init Script for RedHat systems
-    # -- FC15+ have a systemd service for conntrackd in their rpm package
-    #'CentOS', 'Fedora', 'Scientific': {
-    #  $service_name       = 'FIXME/TODO'
-    #  $service_hasrestart = true
-    #  $service_hasstatus  = true
-    #  $service_pattern    = $service_name
-    #  $service_status     = '/usr/bin/pgrep conntrackd >/dev/null'
-    #}
-    'Debian', 'Ubuntu': {
+  case $::osfamily {
+    'RedHat': {
+      $service_name       = 'conntrackd'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = $service_name
+      $service_status     = '/usr/bin/pgrep conntrackd >/dev/null'
+    }
+    'Debian': {
       $service_name       = 'conntrackd'
       $service_hasrestart = true
       $service_hasstatus  = true
@@ -79,8 +77,9 @@ class conntrackd::params {
   }
 
   # location of configuration file
-  $config_dir      = '/etc/conntrackd'
-  $config_filename = 'conntrackd.conf'
+  $config_dir              = '/etc/conntrackd'
+  $config_filename         = 'conntrackd.conf'
+  $primary-backup_filename = 'primary-backup.sh'
 
   # Configuration file parameters
   # -- Set the hashlimit to be double the sysctl value of net.nf_conntrack_max

--- a/templates/conntrackd.conf.RedHat.erb
+++ b/templates/conntrackd.conf.RedHat.erb
@@ -1,0 +1,98 @@
+Sync {
+	Mode <%= sync_mode %> {
+<% if sync_mode == 'FTFW' -%>
+		ResendQueueSize <%= resend_queue_size %>
+		ACKWindowSize <%= ack_window_size %>
+<% elsif sync_mode == 'NOTRACK' -%>
+		DisableInternalCache <%= disable_internal_cache %>
+<% elsif sync_mode == 'ALARM' -%>
+        RefreshTime <%= refresh_time %>
+        CacheTimeout <%= cache_timeout %>
+<% end -%>
+		CommitTimeout <%= commit_timeout %>
+		PurgeTimeout <%= purge_timeout %>
+	}
+
+<% if protocol == 'Multicast' -%>
+	Multicast {
+		IPv4_address <%= ipv4_address %>
+		Group <%= mcast_group %>
+		IPv4_interface <%= ipv4_interface %>
+		Interface <%= interface %>
+		SndSocketBuffer <%= sndsocketbuffer %>
+		RcvSocketBuffer <%= rcvsocketbuffer %>
+		Checksum <%= checksum %>
+	}
+<%   elsif protocol == 'UDP' -%>
+	UDP {
+<%   if @ipv4_address -%>
+		IPv4_address <%= ipv4_address %>
+		IPv4_Destination_Address <%= udp_ipv4_dest %>
+<%   elsif @ipv6_address -%>
+		IPv6_address <%= udp_ipv6_address %>
+		IPv6_Destination_Address <%= udp_ipv6_dest %>
+<%   end -%>
+		Port <%= udp_port %>
+		Interface <%= interface %>
+		SndSocketBuffer <%= sndsocketbuffer %>
+		RcvSocketBuffer <%= rcvsocketbuffer %>
+		Checksum <%= checksum %>
+	}
+<% end -%>
+
+}
+
+General {
+	Nice <%= nice %>
+
+	Scheduler {
+		Type <%= scheduler_type %>
+		Priority <%= scheduler_priority %>
+	}
+
+	HashSize <%= hashsize %>
+	HashLimit <%= hashlimit %>
+	LogFile <%= logfile %>
+	Syslog <%= syslog %>
+	LockFile <%= lockfile %>
+
+	UNIX {
+		Path <%= sock_path %>
+		Backlog <%= sock_backlog %>
+	}
+
+	NetlinkBufferSize <%= netlinkbuffersize %>
+	NetlinkBufferSizeMaxGrowth <%= netlinkbuffersizemaxgrowth %>
+	NetlinkOverrunResync <%= netlinkoverrunresync %>
+<% if @pollsecs -%>
+	PollSecs <%= pollsecs %>
+<% end -%>
+	EventIterationLimit <%= eventiterationlimit %>
+
+	Filter From Userspace {
+		Protocol Accept {
+<% filter_accept_protocols.each do |proto| -%>
+                    <%= proto %>
+<% end -%>
+		}
+
+		Address Ignore {
+<% ignore_ips_ipv4.each do |address| -%>
+			IPv4_address <%= address %>
+<% end -%>
+<% ignore_ips_ipv6.each do |address| -%>
+			IPv6_address <%= address %>
+<% end -%>
+		}
+		State Accept {
+			<%= track_tcp_states.join(' ') %> for TCP
+		}
+	}
+}
+<% if @stats_logfile or @stats_syslog %>
+Stats {
+    LogFile <%= stats_logfile %>
+    NetlinkEventsReliable <%= stats_netlink_reliable %>
+    Syslog <%= stats_syslog %>
+}
+<% end -%>


### PR DESCRIPTION
Not yet tested in production, but the daemons start, and sync correctly. (Only tested Multicast thus far).

Conntrack-tools version is very old though. Unfortunately without changing lots of libraries was the only version that built on a EL6 based system. 