### PR TITLE
Make the default ipv4 multicast address an actual multicast address

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,7 +119,7 @@ class conntrackd::params {
 
   $protocol = 'Multicast'
   $interface = undef
-  $ipv4_address = '255.0.0.50'
+  $ipv4_address = '225.0.0.50'
   $ipv4_interface = undef
   $mcast_group = '3780'
   $sndsocketbuffer = 1249280


### PR DESCRIPTION
I believe this is meant to be `225.0.0.50`, which is actual the value from the examples in the documentation. `255.0.0.50` isn't a valid address.