### PR TITLE
Use getvar() on $::nf_conntrack_max for strict variables compliance

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class conntrackd::params {
   # Configuration file parameters
   # -- Set the hashlimit to be double the sysctl value of net.nf_conntrack_max
   #    uses custom fact defined in this module
-  if $::nf_conntrack_max {
+  if getvar('::nf_conntrack_max') {
       $hashlimit = $::nf_conntrack_max * 2
   } else {
       $hashlimit = 131072


### PR DESCRIPTION
On nodes where the nf_conntrack_max fact doesn't return anything because
no conntrack modules are loaded the $::nf_conntrack_max variable is
nil/undef. Under Puppet 4 or Puppet 3 with future parser and
strict_variables=true this leads to failure in catalog compilation
because undef variables are no longer automatically evaluated as false
and can therefore no longer be used in conditional statements.

The stdlib function getvar() is a backwards compatible way around this
problem.